### PR TITLE
chore: Add Playwright UI E2E tests and CI workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -36,6 +36,9 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
 
+      - name: dotnet tool restore
+        run: dotnet tool restore
+
       - uses: dotnet/nbgv@master
         id: nbgv
         with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -45,3 +45,32 @@ jobs:
       - name: dotnet test
         id: tests
         run: docker compose -f docker-compose.tests.yml up --abort-on-container-exit --build --exit-code-from tests --quiet-pull --no-log-prefix --no-color
+
+  ui-e2e-tests:
+    name: UI E2E Tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - name: git checkout
+        uses: actions/checkout@v3
+        with:
+          clean: false
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
+
+      - name: run ui e2e tests
+        run: docker compose -f docker-compose.ui-tests.yml up --abort-on-container-exit --build --exit-code-from ui-tests --quiet-pull --no-log-prefix --no-color
+
+      - name: upload playwright artifacts on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-artifacts
+          path: |
+            tests/e2e/test-results
+            tests/e2e/playwright-report
+          if-no-files-found: ignore
+
+      - name: docker compose down
+        if: always()
+        run: docker compose -f docker-compose.ui-tests.yml down -v

--- a/.gitignore
+++ b/.gitignore
@@ -78,3 +78,6 @@ _ReSharper*/
 **/wwwroot/js/min/
 **/wwwroot/css/min/
 /artifacts/**/*
+/tests/e2e/playwright-report/
+/tests/e2e/test-results/
+/test-results/

--- a/README.md
+++ b/README.md
@@ -3,4 +3,18 @@ Accounting system for dogs
 
 # Building
 
-Execute the following inside `DoggyFrictions.ExternalApi` directory: `npm install && gulp`.
+Preferred root-level commands:
+
+- Install frontend dependencies: `npm run web:deps`
+- Build frontend assets: `npm run web:build`
+- Build production frontend assets: `npm run web:build:prod`
+
+UI end-to-end tests:
+
+- Install E2E dependencies: `npm run ui:deps`
+- Run E2E against an already-running app: `npm run ui:test`
+- Run E2E in headed mode (local debugging): `npm run ui:test:headed`
+- Run E2E via Docker Compose (starts app + mongo + tests): `npm run ui:test:compose`
+- Tear down E2E Compose stack manually: `npm run ui:test:compose:down`
+
+CI uses raw Docker Compose (`docker-compose.ui-tests.yml`) for PR UI checks.

--- a/docker-compose.ui-tests.yml
+++ b/docker-compose.ui-tests.yml
@@ -1,0 +1,30 @@
+services:
+  mongo:
+    image: mongo
+
+  external-api:
+    build:
+      context: .
+      target: final
+    environment:
+      - "ConnectionStrings__mongo=mongodb://mongo/"
+    depends_on:
+      - mongo
+
+  ui-tests:
+    image: mcr.microsoft.com/playwright:v1.58.2-jammy
+    working_dir: /workspace
+    depends_on:
+      - external-api
+    environment:
+      - "BASE_URL=http://external-api/api"
+      - "CI=true"
+    volumes:
+      - ".:/workspace"
+    command: >-
+      bash -lc "
+      cd tests/e2e
+      && node ./scripts/wait-for-url.mjs http://external-api/api/Sessions
+      && npm ci
+      && npx playwright test
+      "

--- a/package.json
+++ b/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "doggyfrictions-root",
+  "private": true,
+  "scripts": {
+    "web:deps": "npm --prefix src/DoggyFrictions.ExternalApi install",
+    "web:build": "npm --prefix src/DoggyFrictions.ExternalApi run build",
+    "web:build:prod": "npm --prefix src/DoggyFrictions.ExternalApi run build:prod",
+    "ui:deps": "npm --prefix tests/e2e ci",
+    "ui:test": "npm --prefix tests/e2e run test",
+    "ui:test:headed": "npm --prefix tests/e2e run test:headed",
+    "ui:test:compose": "npm --prefix tests/e2e run test:compose",
+    "ui:test:compose:down": "docker compose -f docker-compose.ui-tests.yml down -v"
+  }
+}

--- a/src/DoggyFrictions.ExternalApi/Views/Templates/Action.cshtml
+++ b/src/DoggyFrictions.ExternalApi/Views/Templates/Action.cshtml
@@ -1,5 +1,5 @@
 ﻿<script type="text/html" id="action-template">
-    <div class="action" data-bind="css: {'is-edit': $root.IsEdit(), 'is-preview': !$root.IsEdit()}">
+    <div class="action" data-testid="action-view" data-bind="css: {'is-edit': $root.IsEdit(), 'is-preview': !$root.IsEdit()}">
         <div class="form-horizontal">
             <div class="jumbotron">
                 <div>
@@ -39,7 +39,7 @@
                                     <td class="wide-cell">
                                         <!-- ko if: $root.IsEdit() -->
                                         <div class="form-group">
-                                            <input type="text" class="form-control" data-bind="value: Description, attr: {tabindex: window.App.GlobalId.Next() + 10}, hasFocus: HasFocus" placeholder="Что делим?"/>
+                                            <input type="text" class="form-control" data-testid="consumption-description-input" data-bind="value: Description, attr: {tabindex: window.App.GlobalId.Next() + 10}, hasFocus: HasFocus" placeholder="Что делим?"/>
                                         </div>
                                         <!-- /ko -->
                                         <!-- ko if: !$root.IsEdit() -->
@@ -49,7 +49,7 @@
                                     <td class="money-cell">
                                         <!-- ko if: $root.IsEdit() -->
                                         <div class="form-group">
-                                            <input type="text" class="form-control" data-bind="money: Amount, attr: {tabindex: window.App.GlobalId.Next() + 10}" placeholder="Сумма">
+                                            <input type="text" class="form-control" data-testid="consumption-amount-input" data-bind="money: Amount, attr: {tabindex: window.App.GlobalId.Next() + 10}" placeholder="Сумма">
                                         </div>
                                         <!-- /ko -->
                                         <!-- ko if: !$root.IsEdit() -->
@@ -59,7 +59,7 @@
                                     <td class="small-cell">
                                         <!-- ko if: $root.IsEdit() -->
                                         <div class="form-group">
-                                            <input type="text" class="form-control" data-bind="value: Quantity, attr: {tabindex: window.App.GlobalId.Next() + 10}" placeholder="Кол-во">
+                                            <input type="text" class="form-control" data-testid="consumption-quantity-input" data-bind="value: Quantity, attr: {tabindex: window.App.GlobalId.Next() + 10}" placeholder="Кол-во">
                                         </div>
                                         <!-- /ko -->
                                         <!-- ko if: !$root.IsEdit() -->
@@ -97,7 +97,7 @@
                                 <!-- ko if: $root.IsEdit() -->
                                 <tr>
                                     <td class="actions-cell">
-                                        <button type="button" class="btn btn-primary" data-bind="click: AddConsumption">
+                                        <button type="button" class="btn btn-primary" data-testid="add-consumption-button" data-bind="click: AddConsumption">
                                             <span><span class="glyphicon glyphicon-plus"></span> Добавить</span>
                                         </button>
                                     </td>
@@ -148,7 +148,7 @@
                                 </td>
                                 <td class="money-cell">
                                     <!-- ko if: $root.IsEdit() -->
-                                    <input type="text" class="form-control" data-bind="money: Amount, attr: {tabindex: window.App.GlobalId.Next() + 1000}" placeholder="Сумма">
+                                    <input type="text" class="form-control" data-testid="payer-amount-input" data-bind="money: Amount, attr: {tabindex: window.App.GlobalId.Next() + 1000}" placeholder="Сумма">
                                     <!-- /ko -->
                                     <!-- ko if: !$root.IsEdit() -->
                                     <span data-bind="text: Amount().formatMoney()"></span>
@@ -162,7 +162,7 @@
                             <!-- ko if: $root.IsEdit() -->
                             <tr>
                                 <td class="actions-cell">
-                                    <button type="button" class="btn btn-primary" data-bind="click: AddPayer">
+                                    <button type="button" class="btn btn-primary" data-testid="add-payer-button" data-bind="click: AddPayer">
                                         <span><span class="glyphicon glyphicon-plus"></span> Добавить</span>
                                     </button>
                                 </td>
@@ -174,7 +174,7 @@
                     <div class="">
                         <!-- ko if: $root.IsEdit() -->
                         <div class="form-group">
-                            <button type="button" class="btn btn-primary btn-raised" data-bind="click: Save">
+                            <button type="button" class="btn btn-primary btn-raised" data-testid="save-action-button" data-bind="click: Save">
                                 <span class="glyphicon glyphicon-floppy-save"></span> Сохранить постанову
                             </button>
                             <!-- ko if: !$root.Id -->

--- a/src/DoggyFrictions.ExternalApi/Views/Templates/ActionHeader.cshtml
+++ b/src/DoggyFrictions.ExternalApi/Views/Templates/ActionHeader.cshtml
@@ -7,17 +7,17 @@
             <!-- ko if: $root.IsEdit() -->
             <label>Название</label>
             <span class="input-group">
-                <input type="text" class="form-control" data-bind="value: Description, attr: {tabindex: window.App.GlobalId.Next()}" placeholder="Поясни суть">
+                <input type="text" class="form-control" data-testid="action-description-input" data-bind="value: Description, attr: {tabindex: window.App.GlobalId.Next()}" placeholder="Поясни суть">
                 <span class="input-group-addon"><span class="glyphicon glyphicon-tag"></span></span>
             </span>
             <!-- /ko -->
             <!-- ko if: !$root.IsEdit() -->
-            <span data-bind="text: (Description() || '')"></span>
+            <span data-testid="action-title" data-bind="text: (Description() || '')"></span>
             <!-- /ko -->
             <!-- ko if: $root.IsEdit() -->
             <label>Дата</label>
             <span class="input-group">
-                <input type="text" class="form-control date-input" data-bind="value: Date, attr: {tabindex: window.App.GlobalId.Next()}" placeholder="Укажи дату">
+                <input type="text" class="form-control date-input" data-testid="action-date-input" data-bind="value: Date, attr: {tabindex: window.App.GlobalId.Next()}" placeholder="Укажи дату">
                 <span class="input-group-addon"><span class="glyphicon glyphicon-calendar"></span></span>
             </span>
             <!-- /ko -->

--- a/src/DoggyFrictions.ExternalApi/Views/Templates/ConfirmDialog.cshtml
+++ b/src/DoggyFrictions.ExternalApi/Views/Templates/ConfirmDialog.cshtml
@@ -10,7 +10,7 @@
                     <span data-bind="text: Message"></span>
                 </div>
                 <div class="modal-footer">
-                    <button type="submit" class="btn btn-raised btn-primary" data-dismiss="modal" data-bind="click: Submit">Да</button>
+                    <button type="submit" class="btn btn-raised btn-primary" data-testid="confirm-dialog-yes" data-dismiss="modal" data-bind="click: Submit">Да</button>
                     <button type="button" class="btn btn-primary" data-dismiss="modal">Нет</button>
                 </div>
             </div>

--- a/src/DoggyFrictions.ExternalApi/Views/Templates/Debts.cshtml
+++ b/src/DoggyFrictions.ExternalApi/Views/Templates/Debts.cshtml
@@ -1,37 +1,37 @@
 ﻿<script type="text/html" id="debts-template">
-    <div class="debts jumbotron is-preview">
+    <div class="debts jumbotron is-preview" data-testid="debts-view">
         <div>
             @await Html.PartialAsync("DebtsHeader")
             <h4>Балансы:</h4>
             <!-- ko if: Balances.length -->
-            <div class="debt-balances-block" data-bind="foreach: Balances">
-                <span class="balance-span" data-bind="if: Balance">
-                    <span data-bind="text: Name + ': '"></span>
-                    <span data-bind="text: Balance.formatMoney(), css:{'text-danger':Balance < 0, 'text-success':Balance > 0}"></span>
+            <div class="debt-balances-block" data-testid="balances-list" data-bind="foreach: Balances">
+                <span class="balance-span" data-testid="balance-row" data-bind="if: Balance">
+                    <span data-testid="balance-name" data-bind="text: Name + ': '"></span>
+                    <span data-testid="balance-amount" data-bind="text: Balance.formatMoney(), css:{'text-danger':Balance < 0, 'text-success':Balance > 0}"></span>
                 </span>
             </div>
             <!-- /ko -->
-            <span data-bind="if: !Balances.length">Всё ровно</span>
+            <span data-testid="balances-empty" data-bind="if: !Balances.length">Всё ровно</span>
             <h4>Долговая яма:</h4>
             <!-- ko if: Debts.length -->
             <table>
                 <tbody data-bind="foreach: Debts">
-                <tr class="debt-block">
-                    <td class="wide-cell" data-bind="text: Debtor"></td>
+                <tr class="debt-block" data-testid="debt-row">
+                    <td class="wide-cell" data-testid="debt-debtor" data-bind="text: Debtor"></td>
                     <td class="money-cell">
-                        <span class="" data-bind="text: Amount.formatMoney()"></span>
+                        <span class="" data-testid="debt-amount" data-bind="text: Amount.formatMoney()"></span>
                         <i class="glyphicon text-success glyphicon-arrow-right"></i>
                     </td>
-                    <td class="wide-cell text-right" data-bind="text: Creditor"></td>
+                    <td class="wide-cell text-right" data-testid="debt-creditor" data-bind="text: Creditor"></td>
                     <td class="actions-cell">
-                        <a class="btn btn-sm btn-primary" data-bind="ifConfirmed: $parent.PayOff,
+                        <a class="btn btn-sm btn-primary" data-testid="debt-payoff-button" data-bind="ifConfirmed: $parent.PayOff,
                            cdTitle: 'Погасить долг', cdMessage: 'Будет создана постанова для полного погашения долга между ' + Creditor + ' и ' + Debtor">Погасить</a>
                     </td>
                 </tr>
                 </tbody>
             </table>
             <!-- /ko -->
-            <span data-bind="if: !Debts.length">Всё ровно</span>
+            <span data-testid="debts-empty" data-bind="if: !Debts.length">Всё ровно</span>
         </div>
     </div>
 </script>

--- a/src/DoggyFrictions.ExternalApi/Views/Templates/EditSession.cshtml
+++ b/src/DoggyFrictions.ExternalApi/Views/Templates/EditSession.cshtml
@@ -1,5 +1,5 @@
 ﻿<script type="text/html" id="session-edit-template">
-    <div class="session jumbotron" data-bind="css: {'is-edit': $root.IsEdit(), 'is-preview': !$root.IsEdit()}">
+    <div class="session jumbotron" data-testid="session-edit-view" data-bind="css: {'is-edit': $root.IsEdit(), 'is-preview': !$root.IsEdit()}">
         <div>
             @await Html.PartialAsync("SessionHeader")
 
@@ -16,21 +16,21 @@
                 <!-- ko foreach: Participants-->
                 <tr>
                     <td class="wide-cell">
-                        <input type="text" class="form-control" data-bind="value: Name" placeholder="Погоняло есть?">
+                        <input type="text" class="form-control" data-testid="participant-name-input" data-bind="value: Name" placeholder="Погоняло есть?">
                     </td>
                     <td class="actions-cell"><button type="button" class="btn btn-primary" data-bind="click: $parent.DeleteParticipant"><span class="glyphicon glyphicon-trash"></span></button></td>
                 </tr>
                 <!-- /ko -->
                 <tr>
                     <td class="actions-cell">
-                        <button type="button" class="btn btn-primary" data-bind="click: AddParticipant">
+                        <button type="button" class="btn btn-primary" data-testid="add-participant-button" data-bind="click: AddParticipant">
                             <span><span class="glyphicon glyphicon-plus"></span> Добавить</span>
                         </button>
                     </td>
                 </tr>
                 </tbody>
             </table>
-            <button type="submit" class="btn btn-primary btn-raised" data-bind="click: Save"><span class="glyphicon glyphicon-floppy-save"></span> Сохранить тёрку</button>
+            <button type="submit" class="btn btn-primary btn-raised" data-testid="save-session-button" data-bind="click: Save"><span class="glyphicon glyphicon-floppy-save"></span> Сохранить тёрку</button>
             <button type="button" class="btn btn-primary" data-bind="ifConfirmed: window.App.Functions.Move(Navigation.Back().Url),
                 cdTitle: 'Отмена изменений', cdMessage: 'Изменения не будут сохранены. Вы уверены, что хотите покинуть страницу?' ">
                 Отмена

--- a/src/DoggyFrictions.ExternalApi/Views/Templates/Session.cshtml
+++ b/src/DoggyFrictions.ExternalApi/Views/Templates/Session.cshtml
@@ -1,16 +1,16 @@
 ﻿<script type="text/html" id="session-template">
-    <div class="session jumbotron" data-bind="css: {'is-edit': $root.IsEdit(), 'is-preview': !$root.IsEdit()}">
+    <div class="session jumbotron" data-testid="session-view" data-bind="css: {'is-edit': $root.IsEdit(), 'is-preview': !$root.IsEdit()}">
         <div>
             @await Html.PartialAsync("SessionHeader")
 
             <h4>Собаки:</h4>
             <div data-bind="if: !Participants().length">Собак нет</div>
             <!-- ko if: Participants().length -->
-            <div data-bind="text: _.reduce(Participants(), function(memo, p) { return (memo.Name ? memo.Name() : memo) + ', ' + p.Name() })"></div>
+            <div data-testid="session-participants-summary" data-bind="text: _.reduce(Participants(), function(memo, p) { return (memo.Name ? memo.Name() : memo) + ', ' + p.Name() })"></div>
             <!-- /ko -->
 
-            <a class="btn btn-primary" data-bind="attr: {href: '#/Session/' + Id + '/Action/Create'}"><span class="glyphicon glyphicon-plus"></span> Внести постанову</a>
-            <a class="btn btn-primary" data-bind="attr: {href: '#/Session/' + Id + '/Debts'}"><span class="glyphicon glyphicon-transfer"></span>  Пояснить за долги</a>
+            <a class="btn btn-primary" data-testid="create-action-button" data-bind="attr: {href: '#/Session/' + Id + '/Action/Create'}"><span class="glyphicon glyphicon-plus"></span> Внести постанову</a>
+            <a class="btn btn-primary" data-testid="session-debts-button" data-bind="attr: {href: '#/Session/' + Id + '/Debts'}"><span class="glyphicon glyphicon-transfer"></span>  Пояснить за долги</a>
 
             <div>
                 <h4 class="pull-left">Постановы:</h4>
@@ -29,7 +29,7 @@
                 <span data-bind="if: !Rows().length">Пока всё тихо</span>
                 <table class="table table-clickable" data-bind="if: Rows().length">
                     <thead>
-                        <tr>
+                        <tr data-testid="session-action-row">
                             <th class="small-cell">Дата</th>
                             <th class="really-wide-cell">Суть</th>
                             <th class="wide-cell">Спонсор(ы)</th>

--- a/src/DoggyFrictions.ExternalApi/Views/Templates/SessionHeader.cshtml
+++ b/src/DoggyFrictions.ExternalApi/Views/Templates/SessionHeader.cshtml
@@ -6,11 +6,11 @@
         <!-- ko if: $root.IsEdit() -->
         <span class="input-group">
             <span class="input-group-addon"><span class="glyphicon glyphicon-tag"></span></span>
-            <input type="text" class="form-control" data-bind="value: Name" placeholder="Что обсуждаем?">
+            <input type="text" class="form-control" data-testid="session-name-input" data-bind="value: Name" placeholder="Что обсуждаем?">
         </span>
         <!-- /ko -->
         <!-- ko if: !$root.IsEdit() -->
-        <span data-bind="text: (Name() || '')"></span>
+            <span data-testid="session-title" data-bind="text: (Name() || '')"></span>
         <!-- /ko -->
         <!-- ko if: !$root.IsEdit() -->
         <a class="btn btn-primary" data-bind="attr: {href: '#/Session/Edit/' + Id}"><span class="glyphicon glyphicon-pencil"></span></a><a class="btn btn-primary" data-bind="ifConfirmed: Delete,

--- a/src/DoggyFrictions.ExternalApi/Views/Templates/Sessions.cshtml
+++ b/src/DoggyFrictions.ExternalApi/Views/Templates/Sessions.cshtml
@@ -1,5 +1,5 @@
 ﻿<script type="text/html" id="sessions-template">
-    <div class="sessions jumbotron is-preview">
+    <div class="sessions jumbotron is-preview" data-testid="sessions-view">
         <div>
             <div class="page-head">
                 <h2 class="text-center">Главная</h2>
@@ -14,8 +14,8 @@
                     </tr>
                 </thead>
                 <tbody data-bind="foreach: Sessions">
-                    <tr>
-                        <td class="really-wide-cell" data-bind="text: Name, click: window.App.Functions.Move('#/Session/' + Id)"></td>
+                    <tr data-testid="session-row">
+                        <td class="really-wide-cell" data-testid="session-name-cell" data-bind="text: Name, click: window.App.Functions.Move('#/Session/' + Id)"></td>
                         <td class="really-wide-cell" data-bind="text: ParticipantNames(), click: window.App.Functions.Move('#/Session/' + Id)"></td>
                         <td class="actions-cell">
                             <a class="btn btn-primary" data-bind="attr: {href: '#/Session/' + Id + '/Debts'}"><span class="glyphicon glyphicon-transfer"></span></a><a class="btn btn-primary" data-bind="attr: {href: '#/Session/Edit/' + Id}"><span class="glyphicon glyphicon-pencil"></span></a><a class="btn btn-primary" data-bind="ifConfirmed: Delete,
@@ -24,7 +24,7 @@
                     </tr>
                 </tbody>
             </table>
-            <a class="btn btn-raised btn-primary" data-bind="attr: {href: '#/Session/Create'}"><span class="glyphicon glyphicon-plus"></span> Начать тёрку</a>
+            <a class="btn btn-raised btn-primary" data-testid="create-session-button" data-bind="attr: {href: '#/Session/Create'}"><span class="glyphicon glyphicon-plus"></span> Начать тёрку</a>
         </div>
     </div>
 </script>

--- a/src/DoggyFrictions.ExternalApi/package.json
+++ b/src/DoggyFrictions.ExternalApi/package.json
@@ -3,6 +3,10 @@
   "name": "doggy-frictions",
   "private": true,
   "type": "module",
+  "scripts": {
+    "build": "gulp",
+    "build:prod": "gulp prod"
+  },
   "devDependencies": {
     "del": "7.0.0",
     "gulp": "4.0.2",

--- a/tests/e2e/package-lock.json
+++ b/tests/e2e/package-lock.json
@@ -1,0 +1,91 @@
+{
+  "name": "doggyfrictions-e2e",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "doggyfrictions-e2e",
+      "devDependencies": {
+        "@playwright/test": "1.58.2",
+        "typescript": "5.8.2"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.58.2.tgz",
+      "integrity": "sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.58.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.2.tgz",
+      "integrity": "sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.58.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.2.tgz",
+      "integrity": "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.8.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.2.tgz",
+      "integrity": "sha512-aJn6wq13/afZp/jT9QZmwEjDqqvSGp1VT5GVg+f/t6/oVyrgXM6BY1h9BRh/O5p3PlUPAe+WuiEZOmb/49RqoQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    }
+  }
+}

--- a/tests/e2e/package.json
+++ b/tests/e2e/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "doggyfrictions-e2e",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "test": "playwright test",
+    "test:headed": "playwright test --headed",
+    "test:compose": "docker compose -f ../../docker-compose.ui-tests.yml up --abort-on-container-exit --build --exit-code-from ui-tests --quiet-pull --no-log-prefix --no-color",
+    "install:browsers": "playwright install chromium"
+  },
+  "devDependencies": {
+    "@playwright/test": "1.58.2",
+    "typescript": "5.8.2"
+  }
+}

--- a/tests/e2e/playwright.config.ts
+++ b/tests/e2e/playwright.config.ts
@@ -1,0 +1,26 @@
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './tests',
+  fullyParallel: false,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? 1 : undefined,
+  timeout: 60_000,
+  expect: {
+    timeout: 10_000
+  },
+  reporter: [
+    ['list'],
+    ['html', { open: 'never' }]
+  ],
+  use: {
+    baseURL: process.env.BASE_URL ?? 'http://localhost:5190/api',
+    viewport: { width: 1440, height: 900 },
+    trace: 'on-first-retry',
+    screenshot: 'only-on-failure',
+    video: 'retain-on-failure',
+    actionTimeout: 15_000,
+    navigationTimeout: 30_000
+  }
+});

--- a/tests/e2e/scripts/wait-for-url.mjs
+++ b/tests/e2e/scripts/wait-for-url.mjs
@@ -1,0 +1,28 @@
+const [url, timeoutArg] = process.argv.slice(2);
+
+if (!url) {
+  console.error('Usage: node wait-for-url.mjs <url> [timeoutMs]');
+  process.exit(1);
+}
+
+const timeoutMs = Number(timeoutArg ?? 120_000);
+const pollIntervalMs = 2_000;
+const startedAt = Date.now();
+
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+while (Date.now() - startedAt < timeoutMs) {
+  try {
+    const response = await fetch(url);
+    if (response.ok) {
+      process.exit(0);
+    }
+  } catch {
+    // Keep waiting until timeout.
+  }
+
+  await sleep(pollIntervalMs);
+}
+
+console.error(`Timed out waiting for ${url}`);
+process.exit(1);

--- a/tests/e2e/tests/doggy-frictions.e2e.spec.ts
+++ b/tests/e2e/tests/doggy-frictions.e2e.spec.ts
@@ -1,0 +1,84 @@
+import { expect, test } from '@playwright/test';
+import {
+  createDebtProducingActionViaUi,
+  createSessionViaUi,
+  gotoSessions,
+  openDebtsPage,
+  uniqueName
+} from './helpers';
+
+test.describe('DoggyFrictions UI end-to-end', () => {
+  test('creates a new session from the UI', async ({ page }) => {
+    const sessionName = uniqueName('e2e-session');
+    const participants: [string, string] = [uniqueName('Alpha'), uniqueName('Bravo')];
+
+    const session = await createSessionViaUi(page, sessionName, participants);
+    await gotoSessions(page);
+
+    const matchingSessionRow = page.getByTestId('session-row').filter({ hasText: session.name });
+
+    await expect(matchingSessionRow).toHaveCount(1);
+    await expect(matchingSessionRow.first()).toContainText(participants[0]);
+    await expect(matchingSessionRow.first()).toContainText(participants[1]);
+  });
+
+  test('creates an action and shows corresponding debt', async ({ page }) => {
+    const sessionName = uniqueName('e2e-debt-session');
+    const creditor = uniqueName('Alice');
+    const debtor = uniqueName('Bob');
+    const actionDescription = uniqueName('Dinner');
+
+    const session = await createSessionViaUi(page, sessionName, [creditor, debtor]);
+    await createDebtProducingActionViaUi(page, session, actionDescription);
+
+    await openDebtsPage(page, session.id);
+
+    const debtRow = page.getByTestId('debt-row').first();
+    await expect(debtRow).toBeVisible();
+    await expect(debtRow.getByTestId('debt-debtor')).toHaveText(debtor);
+    await expect(debtRow.getByTestId('debt-creditor')).toHaveText(creditor);
+    await expect(debtRow.getByTestId('debt-amount')).toContainText('50.00');
+
+    const creditorBalanceRow = page.getByTestId('balance-row').filter({ hasText: creditor });
+    const debtorBalanceRow = page.getByTestId('balance-row').filter({ hasText: debtor });
+    await expect(page.getByTestId('balance-row')).toHaveCount(2);
+    await expect(creditorBalanceRow).toHaveCount(1);
+    await expect(debtorBalanceRow).toHaveCount(1);
+    await expect(creditorBalanceRow.getByTestId('balance-amount')).toHaveText('50.00₽');
+    await expect(debtorBalanceRow.getByTestId('balance-amount')).toHaveText('-50.00₽');
+    await expect(page.getByTestId('balances-empty')).toBeHidden();
+  });
+
+  test('pays off a debt and creates a payoff action', async ({ page }) => {
+    const sessionName = uniqueName('e2e-payoff-session');
+    const creditor = uniqueName('Alice');
+    const debtor = uniqueName('Bob');
+    const actionDescription = uniqueName('Rent');
+
+    const session = await createSessionViaUi(page, sessionName, [creditor, debtor]);
+    await createDebtProducingActionViaUi(page, session, actionDescription);
+    await openDebtsPage(page, session.id);
+
+    const payoffResponsePromise = page.waitForResponse((response) => {
+      return response.request().method() === 'POST' && response.url().includes('/MoveMoney');
+    });
+    const debtsReloadPromise = page.waitForResponse((response) => {
+      return response.request().method() === 'GET' && response.url().includes(`/Debts/${session.id}`);
+    });
+
+    await page.getByTestId('debt-payoff-button').first().click();
+    await page.getByTestId('confirm-dialog-yes').click();
+    const payoffResponse = await payoffResponsePromise;
+    await debtsReloadPromise;
+
+    expect(payoffResponse.ok()).toBeTruthy();
+    await expect(page.getByTestId('debt-row')).toHaveCount(0);
+    await expect(page.getByTestId('balance-row')).toHaveCount(0);
+    await expect(page.getByTestId('balances-empty')).toBeVisible();
+    await expect(page.getByTestId('debts-empty')).toBeVisible();
+
+    await page.goto(`/#/Session/${session.id}`);
+    await expect(page.getByTestId('session-view')).toBeVisible();
+    await expect(page.getByTestId('session-view')).toContainText(`${debtor} -> ${creditor}`);
+  });
+});

--- a/tests/e2e/tests/helpers.ts
+++ b/tests/e2e/tests/helpers.ts
@@ -1,0 +1,94 @@
+import { expect, type Locator, type Page } from '@playwright/test';
+
+export type SessionFixture = {
+  id: string;
+  name: string;
+  participants: [string, string];
+};
+
+const SESSION_ID_PATTERN = /#\/Session\/([^/?]+)/;
+
+export function uniqueName(prefix: string): string {
+  const randomSuffix = Math.floor(Math.random() * 100_000);
+  return `${prefix}-${Date.now()}-${randomSuffix}`;
+}
+
+function readSessionIdFromUrl(url: string): string {
+  const match = url.match(SESSION_ID_PATTERN);
+  if (!match?.[1]) {
+    throw new Error(`Unable to parse session id from url: ${url}`);
+  }
+  return match[1];
+}
+
+async function forceMoneyInputCommit(locator: Locator, value: string): Promise<void> {
+  await locator.fill(value);
+  await locator.dispatchEvent('change');
+}
+
+export async function gotoSessions(page: Page): Promise<void> {
+  await page.goto('/#/Sessions');
+  await expect(page.getByTestId('sessions-view')).toBeVisible();
+  await expect(page.getByTestId('create-session-button')).toBeVisible();
+}
+
+export async function createSessionViaUi(
+  page: Page,
+  sessionName: string,
+  participants: [string, string]
+): Promise<SessionFixture> {
+  await gotoSessions(page);
+  await page.getByTestId('create-session-button').click();
+
+  await expect(page.getByTestId('session-edit-view')).toBeVisible();
+  await page.getByTestId('session-name-input').fill(sessionName);
+
+  for (const participantName of participants) {
+    await page.getByTestId('add-participant-button').click();
+    const inputs = page.getByTestId('participant-name-input');
+    const index = (await inputs.count()) - 1;
+    await inputs.nth(index).fill(participantName);
+    await inputs.nth(index).dispatchEvent('change');
+  }
+
+  await page.getByTestId('save-session-button').click();
+  await expect(page.getByTestId('session-view')).toBeVisible();
+  await expect(page.getByTestId('session-title')).toHaveText(sessionName);
+
+  const summary = page.getByTestId('session-participants-summary');
+  await expect(summary).toContainText(participants[0]);
+  await expect(summary).toContainText(participants[1]);
+
+  return {
+    id: readSessionIdFromUrl(page.url()),
+    name: sessionName,
+    participants
+  };
+}
+
+export async function createDebtProducingActionViaUi(
+  page: Page,
+  session: SessionFixture,
+  actionDescription: string
+): Promise<void> {
+  await page.goto(`/#/Session/${session.id}/Action/Create`);
+  await expect(page.getByTestId('action-view')).toBeVisible();
+
+  await page.getByTestId('action-description-input').fill(actionDescription);
+  await page.getByTestId('add-consumption-button').click();
+
+  await page.getByTestId('consumption-description-input').first().fill('Dinner');
+  await forceMoneyInputCommit(page.getByTestId('consumption-amount-input').first(), '100');
+  await forceMoneyInputCommit(page.getByTestId('consumption-quantity-input').first(), '1');
+
+  await page.getByTestId('add-payer-button').click();
+  await expect(page.getByTestId('payer-amount-input').first()).toHaveValue('100');
+
+  await page.getByTestId('save-action-button').click();
+  await expect(page.getByTestId('action-title')).toHaveText(actionDescription);
+}
+
+export async function openDebtsPage(page: Page, sessionId: string): Promise<void> {
+  await page.goto(`/#/Session/${sessionId}/Debts`);
+  await expect(page.getByTestId('debts-view')).toBeVisible();
+}

--- a/tests/e2e/tsconfig.json
+++ b/tests/e2e/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "skipLibCheck": true,
+    "types": [
+      "node",
+      "@playwright/test"
+    ]
+  },
+  "include": [
+    "./**/*.ts"
+  ]
+}


### PR DESCRIPTION
## Summary
- add Playwright TypeScript E2E test suite under tests/e2e
- cover session creation, debt creation with balances ("Долговая яма" view), and debt payoff flow
- add stable data-testid hooks in Razor templates for E2E selectors
- add Docker Compose runner for UI tests (docker-compose.ui-tests.yml) using Playwright container
- wire UI E2E execution into GitHub Actions for every PR to master and release/v*
- add root-level npm wrappers to run web build and UI tests from repo root

## Validation
- npm run ui:test:compose (from repo root)
- docker compose -f docker-compose.ui-tests.yml config -q
